### PR TITLE
chore: remove unnecessary package

### DIFF
--- a/morty-frontend/package.json
+++ b/morty-frontend/package.json
@@ -22,7 +22,6 @@
     "@ethersproject/units": "^5.7.0",
     "@metamask/detect-provider": "^2.0.0",
     "@perawallet/connect": "^1.3.3",
-    "@testing-library/react-hooks": "^8.0.1",
     "@txnlab/use-wallet": "^2.2.0",
     "@web3auth/base": "^7.1.0",
     "@web3auth/base-provider": "^7.1.1",


### PR DESCRIPTION
Removed @testing-library/react-hooks as it uses an old version of react.